### PR TITLE
Prevented service from starting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+* [PR-1](https://github.com/itk-dev/os2welcome/pull/1)
+  Prevented service from starting
+
+[Unreleased]: https://github.com/itk-dev/os2welcome
+
 ## [1.0.0] - 2024-07-11
 - Vite + react setup
 - Docker compose setup serving static files
 - fake meeting data, that should be deleted
 - Config in json5 format
 - Added tailwind css
-

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -9,3 +9,7 @@ services:
       - app
     volumes:
       - .:/app
+    # we don't want this service to start.
+    # See https://stackoverflow.com/a/77001347/2502647 for details.
+    profiles:
+      - dummy-profile


### PR DESCRIPTION
#### Description

Prevents the `node` service from actually starting.

#### Additional comments or questions

The failing checks is due to missing documentation on how to actually run coding standards checks. Please fix this.